### PR TITLE
fix(web): make sure that map is visible on location tracker page for all devices

### DIFF
--- a/web/pages/location/track/[eventid].tsx
+++ b/web/pages/location/track/[eventid].tsx
@@ -116,8 +116,8 @@ const LocationTrack: React.FC = () => {
               lng={locations[0]?.location.lng}
             />
           </div>
-          <div className="w-full h-4/6 flex gap-4 mb-8 min-h-[420px] max-h-[540px]">
-            <div className="flex-1 rounded-xl min-h-full overflow-hidden shadow-xl">
+          <div className="w-full flex flex-col md:flex-row gap-4 mb-8 h-[420px]">
+            <div className="flex-1 rounded-xl overflow-hidden shadow-xl">
               <Map currentLocation={locations[0]} locations={locations} />
             </div>
             <div className="max-w-md">


### PR DESCRIPTION
## Changes
<!--- High level description of any important changes -->
The map was hidden when visiting the `/location/track/xxx` page on mobile devices, this PR fixes the issue.

## Image

<!--- Is the change something visual? If not you can remove this section -->

## How do I test this?

<!--- What does the reviewer need to know to test your pull request? -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation according to my changes.
- [ ] I have added tests to cover my changes.
