### PR TITLE
fix(navigation): hiden menu on lg screen

### DIFF
--- a/web/src/components/header/index.tsx
+++ b/web/src/components/header/index.tsx
@@ -99,7 +99,7 @@ export const Header: React.FC<IHeader> = ({ tabTitle, isPublic }) => {
                 </svg>
               </label>
               <ul
-                className="menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52"
+                className="menu menu-compact lg:hidden dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52"
                 tabIndex={0}
               >
                 {navLinks}


### PR DESCRIPTION
## Changes
Adding class to the dropdown menu so that we make sure it does not appear on large screen
<!--- High level description of any important changes -->

## Image

<!--- Is the change something visual? If not you can remove this section -->

## How do I test this?

<!--- What does the reviewer need to know to test your pull request? -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation according to my changes.
- [ ] I have added tests to cover my changes.
